### PR TITLE
Update :transaction.vue

### DIFF
--- a/pages/transaction/:transaction.vue
+++ b/pages/transaction/:transaction.vue
@@ -115,7 +115,7 @@
         <v-card>
           <v-card-title class="secondary--text">
             <span class="mr-2 lto-transactions" />
-            {{ $t('transaction.title') }}(s)
+            {{ $t('explorer.tx') }}
           </v-card-title>
           <v-card-text class="pa-0">
             <v-simple-table>


### PR DESCRIPTION
Whenever the transaction is type 11, it should display 'Transfer(s) instead of Transaction(s).