### PR TITLE
Imporove mass transfer in tx list

### DIFF
--- a/locales/en.js
+++ b/locales/en.js
@@ -49,14 +49,18 @@ export default {
       title: 'Balance',
       regular: 'Regular',
       generating: 'Generating',
+      unbonding: 'Unbonding',
+      leasing: 'Leasing',
       available: 'Available',
       effective: 'Effective'
     },
     tooltips: {
       regular: 'The total amount of owned LTO.',
       generating: 'Minimum amount of effective LTO for the past 1000 blocks.',
-      available: 'The total amount spendable that can be spend. ',
-      effective: 'The total amount of owned LTO plus the amount leased towards it.'
+      unbonding: 'Amount of LTO temporarily locked after leasing.',
+      leasing: 'Amount of LTO leasing to a node.',
+      available: 'Amount of LTO that\'s not leased or locked by unbonding.',
+      effective: 'Owned LTO + the amount leased towards it.'
     }
   },
   transaction: {
@@ -76,6 +80,7 @@ export default {
     signature: 'Signature',
     size: 'Size',
     tx: 'Transaction(s)',
+    transfers: 'Transfers',
     amount: 'Amount',
     fee: 'Fee',
     version: 'Version',

--- a/locales/nl.js
+++ b/locales/nl.js
@@ -1,4 +1,0 @@
-// nl.js with Dutch translations
-export default {
-  menu: {}
-}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -157,14 +157,6 @@ export default {
         iso: 'en-US',
         file: 'en.js'
       }
-      /*,
-      {
-        name: 'Nederlands',
-        code: 'nl',
-        iso: 'NL',
-        file: 'nl.js'
-      }
-      */
     ],
     langDir: 'locales/',
     seo: true,

--- a/pages/address/:address.vue
+++ b/pages/address/:address.vue
@@ -271,7 +271,7 @@
               </template>
 
               <template v-slot:item.fee="{ item }">
-                <span v-if="item.type !== 11 || item.sender === address">{{ item.fee | parseAtomic | parseNumber }}</span>
+                {{ item.fee | parseAtomic | parseNumber }}
               </template>
 
               <template v-slot:item.timestamp="{ item }">
@@ -402,11 +402,6 @@
         text: 'Amount',
         align: 'right',
         value: 'amount'
-      },
-      {
-        text: 'Fee',
-        align: 'right',
-        value: 'fee'
       },
       {
         text: 'Timestamp',

--- a/pages/block/_block.vue
+++ b/pages/block/_block.vue
@@ -256,11 +256,11 @@
     }
 
     name(value: number): string {
-      return typeMap[value]?.name || 'Unknown'
+      return typeMap[value]?.description || 'Unknown'
     }
 
     icon(value: number): string {
-      return typeMap[value]?.name || 'mdi-help-circle-outline'
+      return typeMap[value]?.icon || 'mdi-help-circle-outline'
     }
   }
 

--- a/pages/transaction/:transaction.vue
+++ b/pages/transaction/:transaction.vue
@@ -64,11 +64,12 @@
                       {{ $t('explorer.recipient') }}
                     </td>
                     <td>
-                      <nuxt-link :to="{ path: '/address/' + transaction.recipient }">
+                      <nuxt-link v-if="transaction.recipient" :to="{ path: '/address/' + transaction.recipient }">
                         {{ transaction.recipient }}
                       </nuxt-link>
 
-                      <span v-if="!transaction.recipient">N/A</span>
+                      <span v-if="transaction.type === 11">[ {{ transaction.transfers.length }} addresses ]</span>
+                      <span v-if="transaction.type !== 11 && !transaction.recipient">N/A</span>
                     </td>
                   </tr>
 

--- a/pages/transaction/:transaction.vue
+++ b/pages/transaction/:transaction.vue
@@ -94,8 +94,7 @@
                       {{ $t('explorer.signature') }}
                     </td>
                     <td>
-                      <span v-if="transaction.signature">{{ transaction.signature }}</span>
-                      <span v-if="!transaction.signature">N/A</span>
+                      <div v-for="proof in transaction.proofs" v-bind:key="proof">{{ proof }}</div>
                     </td>
                   </tr>
                 </tbody>
@@ -115,7 +114,7 @@
         <v-card>
           <v-card-title class="secondary--text">
             <span class="mr-2 lto-transactions" />
-            {{ $t('explorer.tx') }}
+            {{ $t('explorer.transfers') }}
           </v-card-title>
           <v-card-text class="pa-0">
             <v-simple-table>
@@ -271,6 +270,7 @@
   import * as _ from 'lodash'
   import { Transaction, Transfer } from '../types'
   import { EncoderServiceImpl } from '../../plugins/encoder'
+  import { txTypes } from '~/data/map'
 
   @Component({
 
@@ -349,31 +349,7 @@
     }
 
     name(value: number): string {
-      if (value === 1) {
-        return 'Genesis'
-      } else if (value === 4) {
-        return 'Transfer'
-      } else if (value === 8) {
-        return 'Lease'
-      } else if (value === 9) {
-        return 'Cancel Lease'
-      } else if (value === 11) {
-        return 'Mass Transfer'
-      } else if (value === 13) {
-        return 'Script'
-      } else if (value === 15) {
-        return 'Anchor'
-      } else if (value === 16) {
-        return 'Invoke Association'
-      } else if (value === 17) {
-        return 'Revoke Association'
-      } else if (value === 18) {
-        return 'Sponsor'
-      } else if (value === 19) {
-        return 'Cancel Sponsor'
-      } else {
-        return 'Unknown'
-      }
+      return txTypes[value]?.description || 'Unknown'
     }
   }
 

--- a/plugins/translate.ts
+++ b/plugins/translate.ts
@@ -2,7 +2,6 @@ import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 
 import en from '../locales/en'
-import nl from '../locales/nl'
 
 // register i18n module
 Vue.use(VueI18n)
@@ -10,7 +9,7 @@ Vue.use(VueI18n)
 const i18n = new VueI18n({
   locale: 'en',
   fallbackLocale: 'en',
-  messages: { en, nl },
+  messages: { en },
   silentTranslationWarn: true
 })
 


### PR DESCRIPTION
Improve how mass transfer is displayed in the tx list on the address page.
Show unbonding and leasing balances in address page (instead of generating and available)
Remove the fee column in address overview.