### PR TITLE
Fix payout tooltip on the staking tab

### DIFF
--- a/store/staking.ts
+++ b/store/staking.ts
@@ -23,7 +23,7 @@ const labelMap = new Map(
   (process.env.NETWORK_ID === 'T' ? testnetNodes.nodes : [...communityNodes.nodes, ...otherNodes.nodes])
     .map((node: {address: string; name: string; sharing?: string; payoutSchedule?: string}) => [
       node.address,
-      { label: node.name, payout: node.sharing ? `${node.sharing} | ${node.payoutSchedule}}` : undefined }
+      { label: node.name, payout: node.sharing ? `${node.sharing} | ${node.payoutSchedule}` : undefined }
     ])
 )
 


### PR DESCRIPTION
**Problem**
The tooltip on the staking tab contained an unnecessary "}" at the end of the message, which disrupted the user experience by showing an incorrect tooltip format.

**Solution**
The issue was fixed by correcting the tooltip message in the store/staking.ts file. The "}" was removed to ensure the message displays properly.

**Screenshots**

- **Before the fix:**
![Screenshot from 2025-01-01 13-57-05](https://github.com/user-attachments/assets/5de57740-e66e-4878-90b7-d8326250cfbf)
- **After the fix:**
![Screenshot from 2025-01-01 14-03-46](https://github.com/user-attachments/assets/091fffda-73b0-4890-9605-b5ce86fa6941)
